### PR TITLE
chore: bump nixpkgs + add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "nix": { "enabled": true },
+  "lockFileMaintenance": { "enabled": true, "schedule": ["before 6am on monday"] },
+  "packageRules": [
+    { "matchManagers": ["nix"], "groupName": "nix flake inputs" }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 result
 result-*
 .direnv
+.worktrees/
 CLAUDE.md
 TODO.md
 *.local.bak

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768564909,
-        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
-        "owner": "NixOS",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Hygiene pass on the compliance repo:

- Add `.worktrees/` to `.gitignore` (safety fix).
- Bump nixpkgs from `e4bae1bd10c9` (2026-01-16) to `da5ad661ba4e` (2026-05-10). \`nix flake check --no-build\` passed cleanly — no module renames or option breakage.
- Add `.github/renovate.json` for weekly automated dependency updates.

No code changes; no Rust in this repo.

## Test plan

- [x] `nix flake check --no-build` — all 21 eval tests + 8 nixosModules + VM-test derivation evaluate cleanly
- [ ] `nix flake check` (with builds)
- [ ] `nix build .#checks.x86_64-linux.vm-compliance-evidence`

## Commits

1. `chore: gitignore .worktrees directory`
2. `chore(flake): bump nixpkgs (4 months)`
3. `ci(renovate): add weekly dependency update config`