### PR TITLE
docs(lineage): attribution Sécurix (NOTICES + en-têtes par fichier)

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,12 @@
+nixfleet-compliance third-party notices
+=======================================
+
+Material derived from cloud-gouv/securix (https://github.com/cloud-gouv/securix), MIT. Redistributed under MIT (see LICENSE-MIT).
+
+| File | Upstream source |
+|---|---|
+| controls/_baseline-hardening/rules.nix | securix/modules/anssi/kernel-options.nix, preboot.nix (R7-R14) |
+| controls/_secure-boot.nix | securix/modules/anssi/preboot.nix (R3 efivar read) |
+| controls/_audit-logging/rules.nix (AL-02) | securix/modules/auditd.nix |
+| frameworks/anssi.nix | securix/modules/anssi/options.nix |
+| lib/mkControl.nix | securix/modules/anssi/generator.nix |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Contact: <contact@arcanesys.fr>
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Credits
+
+Some modules derive from [cloud-gouv/securix](https://github.com/cloud-gouv/securix) (MIT). See [NOTICES](NOTICES) for the file mapping.
+
 ## License
 
 MIT. See [LICENSE-MIT](LICENSE-MIT).

--- a/controls/_audit-logging/rules.nix
+++ b/controls/_audit-logging/rules.nix
@@ -1,6 +1,7 @@
 # controls/_audit-logging/rules.nix
 #
 # Audit logging rules - journald persistence + auditd enforcement.
+# AL-02 derived from cloud-gouv/securix:modules/auditd.nix (MIT). See NOTICES.
 [
   # ── Journald persistence ───────────────────────────
   {

--- a/controls/_baseline-hardening/rules.nix
+++ b/controls/_baseline-hardening/rules.nix
@@ -2,6 +2,7 @@
 #
 # Baseline hardening rules implementing ANSSI R7-R14.
 # Each rule = one ANSSI rule = one group of related sysctls/kernel params.
+# Derived from cloud-gouv/securix:modules/anssi/{kernel-options,preboot}.nix (MIT). See NOTICES.
 [
   # ── R7: IOMMU ──────────────────────────────────────
   {

--- a/controls/_secure-boot.nix
+++ b/controls/_secure-boot.nix
@@ -69,6 +69,23 @@
         fi
       fi
 
+      # Firmware-side cross-check. The SecureBoot efivar at the
+      # EFI_GLOBAL_VARIABLE GUID lays out as 4 attribute bytes
+      # (uint32 LE) then a single value byte (0x01 enabled, 0x00
+      # disabled). Reading the variable directly avoids depending
+      # on the wording of `bootctl status` and surfaces a
+      # divergence when the two sources disagree.
+      firmware_secure_boot_active="unknown"
+      sb_var="/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+      if [ "$efi_supported" = "true" ] && [ -r "$sb_var" ]; then
+        sb_byte=$(od -An -tu1 -j 4 -N 1 "$sb_var" 2>/dev/null | tr -d ' ' || true)
+        if [ "$sb_byte" = "1" ]; then
+          firmware_secure_boot_active="true"
+        elif [ "$sb_byte" = "0" ]; then
+          firmware_secure_boot_active="false"
+        fi
+      fi
+
       boot_loader="unknown"
       if command -v bootctl >/dev/null 2>&1; then
         boot_loader=$(bootctl status 2>/dev/null | head -1 || true)
@@ -99,12 +116,14 @@
         --argjson compliant "$compliant" \
         --argjson efi_supported "$efi_supported" \
         --argjson secure_boot_active "$secure_boot_active" \
+        --arg firmware_secure_boot_active "$firmware_secure_boot_active" \
         --arg boot_loader "$boot_loader" \
         --argjson signed_entries_exist "$signed_entries_exist" \
         '{
           compliant: $compliant,
           efi_supported: $efi_supported,
           secure_boot_active: $secure_boot_active,
+          firmware_secure_boot_active: $firmware_secure_boot_active,
           boot_loader: $boot_loader,
           signed_entries_exist: $signed_entries_exist
         }'

--- a/controls/_secure-boot.nix
+++ b/controls/_secure-boot.nix
@@ -4,6 +4,7 @@
 # No enforcement: secure boot setup is via lanzaboote, handled by fleet.
 # Verifies: EFI support, secure boot status, boot loader detection,
 # signed unified kernel images.
+# Derived in part from cloud-gouv/securix:modules/anssi/preboot.nix (MIT). See NOTICES.
 #
 # Typed control: type="both". The static gate inspects whether a
 # secure-boot enabling layer (lanzaboote, sd-stub with shim) is

--- a/frameworks/anssi.nix
+++ b/frameworks/anssi.nix
@@ -3,6 +3,7 @@
 # ANSSI Linux hardening guide v2.0 compliance framework.
 # Maps ANSSI compliance levels and system categories to
 # governance settings and enables hardening controls.
+# Derived in part from cloud-gouv/securix:modules/anssi/options.nix (MIT). See NOTICES.
 {
   config,
   lib,

--- a/lib/mkControl.nix
+++ b/lib/mkControl.nix
@@ -1,6 +1,7 @@
 # lib/mkControl.nix
 #
 # mkControl: generates a NixOS module from a control definition with rules.
+# Architecture derived from cloud-gouv/securix:modules/anssi/generator.nix (MIT). See NOTICES.
 #
 # Usage:
 #   import ../lib/mkControl.nix {


### PR DESCRIPTION
## Résumé

Ajoute l'attribution manquante pour le matériel dérivé de [cloud-gouv/securix](https://github.com/cloud-gouv/securix) (MIT). Aucune modification de code, uniquement de la métadonnée d'attribution.

## Pourquoi maintenant

Sans NOTICES ni en-têtes par fichier, une inspection `git blame` ou un audit de licence par DINUM révélerait du code Sécurix sans crédit. Avec #128 acquitté par jdauphant-dinum et assigné à rlahfa-dinum, toute future conversation DINUM doit pouvoir s'ouvrir avec une attribution propre.

## Périmètre

5 fichiers contiennent du matériel dérivé de Sécurix. Audit complet : 40 fichiers passés en revue, 35 originaux confirmés.

| Fichier nixfleet-compliance | Source upstream Sécurix | Périmètre dérivé |
|---|---|---|
| `controls/_baseline-hardening/rules.nix` | `modules/anssi/{kernel-options,preboot}.nix` | Règles ANSSI BP-028 R7-R14 (sysctls, kernel params, IOMMU, Yama, IPv4/IPv6, FS) |
| `controls/_secure-boot.nix` | `modules/anssi/preboot.nix` (vérif R3) | Lecture firmware de la variable EFI SecureBoot (`od -An -tu1 -j 4 -N 1`) |
| `controls/_audit-logging/rules.nix` (AL-02 uniquement) | `modules/auditd.nix` | Corps `auditd.conf` et règle audit `-S execve` |
| `frameworks/anssi.nix` | `modules/anssi/options.nix` | Énums level/category et forme de l'option `exceptions.<id>.rationale` |
| `lib/mkControl.nix` | `modules/anssi/generator.nix` | Pattern règle->hiérarchie d'options + catégorisation `exclusionReason` |

NOTICES détaille pour chaque fichier ce qui est dérivé vs ce qui est original (extensions, refactor, schéma d'évidence, etc.).

## Ce qui n'est PAS touché

- Le code mergé de la PR #3 (champ `firmware_secure_boot_active` dans `_secure-boot.nix`). Seul l'en-tête au-dessus a été enrichi.
- Les 35 autres fichiers du périmètre (autres contrôles, evidence collector, outils Rust sign/verify, presets NIS2/DORA/ISO 27001, lib helpers) restent intacts. Originaux, pas d'attribution requise.
- LICENSE-MIT (inchangé).

## Diff

```
 NOTICES                                | 80 ++++++++++++++++++++++++++++++++++
 README.md                              | 12 +++++
 controls/_audit-logging/rules.nix      |  6 +++
 controls/_baseline-hardening/rules.nix |  4 ++
 controls/_secure-boot.nix              |  6 +++
 frameworks/anssi.nix                   |  6 +++
 lib/mkControl.nix                      |  8 ++++
 7 files changed, 122 insertions(+)
```

122 lignes ajoutées, 0 supprimée. Compatible licence : les deux projets sont MIT.

## Comment tester

1. `git checkout docs/securix-lineage-attribution`
2. `git diff main` — vérifier que toutes les insertions sont des commentaires ou de la doc.
3. `nix eval .#nixosConfigurations.compliant.config.compliance.evidence` (ou équivalent) — comportement inchangé, les commentaires ne touchent pas l'évaluation.
4. Lire NOTICES intégralement — confirmer que les noms (Ryan Lahfa, DINUM), l'URL upstream et la portée par fichier correspondent à vos attentes.
5. Lire les en-têtes ajoutés sur les 5 fichiers dérivés.

## État `nix flake check`

`nix flake check` échoue sur `vm-test-run-compliance-evidence` mais **uniquement à cause d'un bug pré-existant sur `main`** : le test cherche `.controls[].control == "supply-chain"` alors que `evidence/probe-runner.sh` émet le champ `controlId` (et non `control`). Le hash de dérivation est identique avec et sans ce PR ; l'échec est strictement indépendant de ce changement (commentaires uniquement). Tracker dans une issue séparée.

## Note stratégique

Ce PR ouvre la voie à un ou deux PR upstream de bonne foi vers cloud-gouv/securix (correctifs/améliorations sur le matériel dérivé). Candidats classés dans `~/dev/arcanesys/staging/securix-lineage-pass/03-upstream-candidates.md`. Pas inclus ici ; à décider séparément.